### PR TITLE
ES Public access check

### DIFF
--- a/checks/check1102
+++ b/checks/check1102
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (c) by Toni de la Fuente
+#
+# This Prowler check is licensed under a
+# Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+#
+# You should have received a copy of the license along with this
+# work. If not, see <http://creativecommons.org/licenses/by-nc-sa/4.0/>.
+
+CHECK_ID_check1102="11.2,11.02"
+CHECK_TITLE_check1102="[check1102] Ensure no Elasticsearch Domains allow ingress from 0.0.0.0/0 (Not Scored) (Not part of CIS benchmark)"
+CHECK_SCORED_check1102="NOT_SCORED"
+CHECK_TYPE_check1102="CUSTOM"
+CHECK_ALTERNATE_check1102="check1102"
+
+check1102(){
+
+for regx in $REGIONS; do
+    LIST_OF_ES_DOMAINS=$($AWSCLI es list-domain-names --query 'DomainNames[*]' $PROFILE_OPT --region $regx --output text)
+    if [[ $LIST_OF_ES_DOMAINS ]];then
+        while read -r DOMAIN;do
+            SG=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $DOMAIN --query 'DomainConfig.VPCOptions.Options.SecurityGroupIds' $PROFILE_OPT --region $regx --output text)
+
+	    SG_MATCH=$($AWSCLI ec2 describe-security-groups --group-ids $SG --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`443` && ToPort>=`443`)) && contains(IpRanges[].CidrIp, `0.0.0.0/0`)]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
+
+	    if [[ $SG_MATCH ]];then
+
+               textFail "Found Elasticsearch Domain: $DOMAIN open to 0.0.0.0/0 via Security Group $SG in Region $regx" "$regx"
+
+	   else
+
+	       textPass "Elasticsearch Domain: $DOMAIN not open to 0.0.0.0/0" "regx"
+
+            fi
+
+        done <<< "$LIST_OF_ES_DOMAINS"
+    fi
+
+done
+}

--- a/groups/group11_custom
+++ b/groups/group11_custom
@@ -15,4 +15,4 @@ GROUP_ID[11]='custom'
 GROUP_NUMBER[11]='11.0'
 GROUP_TITLE[11]='Custom Checks - [custom] ****************************'
 GROUP_RUN_BY_DEFAULT[11]='Y' # run it when execute_all is called
-GROUP_CHECKS[11]='check1101'
+GROUP_CHECKS[11]='check1101,check1102'


### PR DESCRIPTION
Added a check for public facing Elasticsearch

Pass:
```
11.2 [check1102] Ensure no Elasticsearch Domains allow ingress from 0.0.0.0/0 (Not Scored) (Not part of CIS benchmark)
       PASS! Elasticsearch Domain: <domainname> not open to 0.0.0.0/0
       PASS! Elasticsearch Domain: <domainname> not open to 0.0.0.0/0
```

Fail:
```
 11.2 [check1102] Ensure no Elasticsearch Domains allow ingress from 0.0.0.0/0 (Not Scored) (Not part of CIS benchmark)
       FAIL! Found Elasticsearch Domain: <domainname> open to 0.0.0.0/0 via Security Group <securitygroup> in Region eu-west-1
       FAIL! Found Elasticsearch Domain: <domainname> open to 0.0.0.0/0 via Security Group <securitygroup> in Region eu-west-1
```
